### PR TITLE
Fix minigames issues

### DIFF
--- a/src/components/games/MemoryGame.tsx
+++ b/src/components/games/MemoryGame.tsx
@@ -7,7 +7,9 @@ interface MemoryGameProps {
 }
 
 const MemoryGame = ({ onPointsEarned }: MemoryGameProps) => {
-  const symbols = ['🎮', '🎯', '⭐', '🎪', '🎨', '🎭', '🎪', '🎵'];
+  // Lista de símbolos usados no jogo. Todos precisam ser únicos para
+  // evitar pares extras que quebram a lógica de conclusão.
+  const symbols = ['🎮', '🎯', '⭐', '🎪', '🎨', '🎭', '👾', '🎵'];
   const [cards, setCards] = useState<Array<{ id: number; symbol: string; isFlipped: boolean; isMatched: boolean }>>([]);
   const [flippedCards, setFlippedCards] = useState<number[]>([]);
   const [gameStarted, setGameStarted] = useState(false);

--- a/src/components/games/QuizBattle.tsx
+++ b/src/components/games/QuizBattle.tsx
@@ -139,6 +139,14 @@ const QuizBattle = ({ onPointsEarned, user }: QuizBattleProps) => {
     }
   };
 
+  // Atualiza a lista de participantes periodicamente enquanto a sala estiver em espera
+  useEffect(() => {
+    if (gameState === 'waiting' && currentRoom) {
+      const interval = setInterval(() => loadParticipants(currentRoom.id), 2000);
+      return () => clearInterval(interval);
+    }
+  }, [gameState, currentRoom]);
+
   const startGame = async () => {
     if (participants.length < 2) {
       toast.error('Precisa de pelo menos 2 jogadores!');

--- a/src/components/games/RacingGame.tsx
+++ b/src/components/games/RacingGame.tsx
@@ -41,6 +41,28 @@ const RacingGame = ({ onPointsEarned, user }: RacingGameProps) => {
     return () => window.removeEventListener('keydown', handleKeyPress);
   }, [handleKeyPress]);
 
+  // Obter o progresso dos outros jogadores enquanto a corrida estiver acontecendo
+  useEffect(() => {
+    if (gameState !== 'playing' || !currentRoom) return;
+
+    const interval = setInterval(async () => {
+      const { data } = await supabase
+        .from('game_participants')
+        .select('user_id, score')
+        .eq('room_id', currentRoom.id);
+
+      if (data) {
+        const progress: { [key: string]: number } = {};
+        data.forEach(p => {
+          progress[p.user_id] = p.score;
+        });
+        setRaceProgress(progress);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [gameState, currentRoom]);
+
   const updateProgress = async (progress: number) => {
     if (!currentRoom || !user) return;
     


### PR DESCRIPTION
## Summary
- ensure MemoryGame has unique symbols
- poll participants while waiting in QuizBattle
- sync racing progress during play

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_683e0ede8fc48321a3179104dac3018d