### PR TITLE
Improve layout with new Instagram link

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,12 @@
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 
     <!-- Google Fonts for retro/pixel style -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,6 @@
 
+import { Mail, Phone, Instagram } from 'lucide-react';
+
 const Footer = () => {
   return (
     <footer className="bg-black/80 py-12 px-4 border-t border-cyan-400/30">
@@ -22,15 +24,29 @@ const Footer = () => {
               Junte pontos, suba no ranking e concorra a prêmios exclusivos!
             </p>
             <div className="flex space-x-4">
-              <div className="w-8 h-8 bg-cyan-400/20 rounded-full flex items-center justify-center cursor-pointer hover:bg-cyan-400/40 transition-colors">
-                <span className="text-cyan-400">📧</span>
-              </div>
-              <div className="w-8 h-8 bg-purple-400/20 rounded-full flex items-center justify-center cursor-pointer hover:bg-purple-400/40 transition-colors">
-                <span className="text-purple-400">📱</span>
-              </div>
-              <div className="w-8 h-8 bg-pink-400/20 rounded-full flex items-center justify-center cursor-pointer hover:bg-pink-400/40 transition-colors">
-                <span className="text-pink-400">📸</span>
-              </div>
+              <a
+                href="mailto:contato@believestore.com"
+                className="w-8 h-8 bg-cyan-400/20 rounded-full flex items-center justify-center hover:bg-cyan-400/40 transition-colors"
+                aria-label="Email"
+              >
+                <Mail className="w-4 h-4 text-cyan-400" />
+              </a>
+              <a
+                href="tel:+5511999999999"
+                className="w-8 h-8 bg-purple-400/20 rounded-full flex items-center justify-center hover:bg-purple-400/40 transition-colors"
+                aria-label="Telefone"
+              >
+                <Phone className="w-4 h-4 text-purple-400" />
+              </a>
+              <a
+                href="https://instagram.com/believestor.e"
+                className="w-8 h-8 bg-pink-400/20 rounded-full flex items-center justify-center hover:bg-pink-400/40 transition-colors"
+                aria-label="Instagram @believestor.e"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Instagram className="w-4 h-4 text-pink-400" />
+              </a>
             </div>
           </div>
 
@@ -51,6 +67,7 @@ const Footer = () => {
             <ul className="space-y-2 text-gray-400">
               <li>📧 contato@believestore.com</li>
               <li>📱 (11) 99999-9999</li>
+              <li>📸 <a href="https://instagram.com/believestor.e" target="_blank" rel="noopener noreferrer" className="hover:text-pink-400">@believestor.e</a></li>
               <li>📍 São Paulo, SP</li>
               <li>🕒 Seg-Sex 9h-18h</li>
             </ul>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -8,15 +8,21 @@ const Hero = () => {
             LEVEL UP!
           </h2>
           <p className="text-xl md:text-2xl text-white mb-8 font-pixel">
-            Sua loja geek definitiva com produtos épicos, mini-games e eventos incríveis!
+            Sua loja geek definitiva de games e animes com produtos épicos, mini-games e eventos incríveis!
           </p>
           <div className="flex flex-col md:flex-row gap-4 justify-center items-center">
-            <button className="bg-gradient-to-r from-cyan-500 to-purple-500 text-white px-8 py-4 rounded-lg font-bold text-lg hover:scale-105 transition-transform shadow-lg shadow-cyan-500/25">
+            <a
+              href="#products"
+              className="bg-gradient-to-r from-cyan-500 to-purple-500 text-white px-8 py-4 rounded-lg font-bold text-lg hover:scale-105 transition-transform shadow-lg shadow-cyan-500/25"
+            >
               EXPLORAR PRODUTOS
-            </button>
-            <button className="bg-gradient-to-r from-pink-500 to-red-500 text-white px-8 py-4 rounded-lg font-bold text-lg hover:scale-105 transition-transform shadow-lg shadow-pink-500/25">
+            </a>
+            <a
+              href="#games"
+              className="bg-gradient-to-r from-pink-500 to-red-500 text-white px-8 py-4 rounded-lg font-bold text-lg hover:scale-105 transition-transform shadow-lg shadow-pink-500/25"
+            >
               JOGAR MINI-GAMES
-            </button>
+            </a>
           </div>
         </div>
       </div>

--- a/src/components/MiniGames.tsx
+++ b/src/components/MiniGames.tsx
@@ -56,24 +56,24 @@ const MiniGames = ({ onPointsEarned, user }: MiniGamesProps) => {
   return (
     <section id="games" className="py-20 px-4 bg-black/20">
       <div className="container mx-auto">
-        <h2 className="text-4xl font-bold text-center mb-12 bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent">
+        <h2 className="text-4xl font-bold text-center mb-12 bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent font-pixel">
           MINI-GAMES
         </h2>
 
         {!activeGame ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-6xl mx-auto">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 max-w-6xl mx-auto">
             {games.map((game) => {
               const IconComponent = game.icon;
               return (
                 <div
                   key={game.id}
-                  className="bg-black/40 backdrop-blur-sm rounded-lg p-8 border border-cyan-400/30 hover:border-cyan-400 transition-all hover:scale-105 text-center"
+                  className="bg-black/40 backdrop-blur-sm rounded-lg p-8 border border-cyan-400/30 hover:border-cyan-400 transition-all hover:scale-105 hover:shadow-xl text-center"
                 >
-                  <div className={`w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-r ${game.color} flex items-center justify-center`}>
+                  <div className={`w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-r ${game.color} flex items-center justify-center animate-pulse`}>
                     <IconComponent className="w-10 h-10 text-white" />
                   </div>
                   <div className="flex items-center justify-center mb-2">
-                    <h3 className="text-2xl font-bold text-white">{game.name}</h3>
+                    <h3 className="text-2xl font-bold text-white font-pixel">{game.name}</h3>
                     {game.multiplayer && (
                       <div className="ml-2" title="Multiplayer">
                         <Users className="w-6 h-6 text-cyan-400" />
@@ -87,7 +87,7 @@ const MiniGames = ({ onPointsEarned, user }: MiniGamesProps) => {
                   <button
                     onClick={() => setActiveGame(game.id)}
                     disabled={game.multiplayer && !user}
-                    className={`bg-gradient-to-r ${game.color} text-white px-8 py-3 rounded-lg font-bold hover:scale-105 transition-transform disabled:opacity-50 disabled:cursor-not-allowed`}
+                    className={`bg-gradient-to-r ${game.color} text-white px-8 py-3 rounded-lg font-bold hover:scale-105 transition-transform disabled:opacity-50 disabled:cursor-not-allowed font-pixel`}
                   >
                     JOGAR AGORA
                   </button>
@@ -99,7 +99,7 @@ const MiniGames = ({ onPointsEarned, user }: MiniGamesProps) => {
           <div className="text-center">
             <button
               onClick={() => setActiveGame(null)}
-              className="mb-8 bg-red-500 text-white px-6 py-2 rounded-lg hover:bg-red-600 transition-colors"
+              className="mb-8 bg-red-500 text-white px-6 py-2 rounded-lg hover:bg-red-600 transition-colors font-pixel"
             >
               VOLTAR AOS JOGOS
             </button>

--- a/src/components/games/MemoryGame.tsx
+++ b/src/components/games/MemoryGame.tsx
@@ -87,7 +87,7 @@ const MemoryGame = ({ onPointsEarned }: MemoryGameProps) => {
   return (
     <div className="bg-black/60 p-8 rounded-lg border border-purple-400/30">
       <div className="text-center mb-6">
-        <h3 className="text-2xl font-bold text-purple-400 mb-2">Memory Game</h3>
+        <h3 className="text-2xl font-bold text-purple-400 mb-2 font-pixel">Memory Game</h3>
         <p className="text-white mb-4">
           Jogadas: {moves} | Encontre todos os pares!
         </p>

--- a/src/components/games/QuizBattle.tsx
+++ b/src/components/games/QuizBattle.tsx
@@ -237,7 +237,7 @@ const QuizBattle = ({ onPointsEarned, user }: QuizBattleProps) => {
       <div className="bg-black/40 backdrop-blur-sm rounded-lg p-8 border border-purple-400/30 text-center">
         <div className="flex items-center justify-center mb-6">
           <Brain className="w-12 h-12 text-purple-400 mr-4" />
-          <h3 className="text-3xl font-bold text-white">Quiz Battle</h3>
+          <h3 className="text-3xl font-bold text-white font-pixel">Quiz Battle</h3>
         </div>
         <p className="text-gray-300 mb-8">Teste seus conhecimentos geek contra outros jogadores!</p>
         
@@ -272,7 +272,7 @@ const QuizBattle = ({ onPointsEarned, user }: QuizBattleProps) => {
   if (gameState === 'waiting') {
     return (
       <div className="bg-black/40 backdrop-blur-sm rounded-lg p-8 border border-purple-400/30 text-center">
-        <h3 className="text-2xl font-bold text-white mb-4">Sala: {roomCode}</h3>
+        <h3 className="text-2xl font-bold text-white mb-4 font-pixel">Sala: {roomCode}</h3>
         <div className="flex items-center justify-center mb-6">
           <Users className="w-8 h-8 text-purple-400 mr-2" />
           <span className="text-white">{participants.length}/4 jogadores</span>
@@ -314,7 +314,7 @@ const QuizBattle = ({ onPointsEarned, user }: QuizBattleProps) => {
           </div>
         </div>
 
-        <h3 className="text-xl font-bold text-white mb-6">{question.question}</h3>
+        <h3 className="text-xl font-bold text-white mb-6 font-pixel">{question.question}</h3>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {question.options.map((option, index) => (
@@ -344,7 +344,7 @@ const QuizBattle = ({ onPointsEarned, user }: QuizBattleProps) => {
     return (
       <div className="bg-black/40 backdrop-blur-sm rounded-lg p-8 border border-purple-400/30 text-center">
         <Trophy className="w-16 h-16 text-yellow-400 mx-auto mb-4" />
-        <h3 className="text-2xl font-bold text-white mb-4">Jogo Finalizado!</h3>
+        <h3 className="text-2xl font-bold text-white mb-4 font-pixel">Jogo Finalizado!</h3>
         <p className="text-xl text-purple-400 mb-6">Sua pontuação: {score}</p>
         
         <button

--- a/src/components/games/RacingGame.tsx
+++ b/src/components/games/RacingGame.tsx
@@ -239,7 +239,7 @@ const RacingGame = ({ onPointsEarned, user }: RacingGameProps) => {
       <div className="bg-black/40 backdrop-blur-sm rounded-lg p-8 border border-orange-400/30 text-center">
         <div className="flex items-center justify-center mb-6">
           <Zap className="w-12 h-12 text-orange-400 mr-4" />
-          <h3 className="text-3xl font-bold text-white">Corrida Espacial</h3>
+          <h3 className="text-3xl font-bold text-white font-pixel">Corrida Espacial</h3>
         </div>
         <p className="text-gray-300 mb-8">Aperte ESPAÇO o mais rápido possível para vencer!</p>
         
@@ -314,7 +314,7 @@ const RacingGame = ({ onPointsEarned, user }: RacingGameProps) => {
     return (
       <div className="bg-black/40 backdrop-blur-sm rounded-lg p-8 border border-orange-400/30">
         <div className="flex justify-between items-center mb-6">
-          <h3 className="text-2xl font-bold text-white">Corrida Espacial</h3>
+          <h3 className="text-2xl font-bold text-white font-pixel">Corrida Espacial</h3>
           <div className="text-orange-400 font-bold">
             Progresso: {playerPosition.toFixed(1)}%
           </div>

--- a/src/components/games/SnakeGame.tsx
+++ b/src/components/games/SnakeGame.tsx
@@ -108,7 +108,7 @@ const SnakeGame = ({ onPointsEarned }: SnakeGameProps) => {
   return (
     <div className="bg-black/60 p-8 rounded-lg border border-green-400/30">
       <div className="text-center mb-6">
-        <h3 className="text-2xl font-bold text-green-400 mb-2">Snake Retrô</h3>
+        <h3 className="text-2xl font-bold text-green-400 mb-2 font-pixel">Snake Retrô</h3>
         <p className="text-white mb-4">Score: {score} | Use as setas para controlar</p>
         
         {!gameRunning ? (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,9 +19,9 @@ export default {
 			}
 		},
 		extend: {
-			fontFamily: {
-				'pixel': ['Orbitron', 'monospace'],
-			},
+                        fontFamily: {
+                                pixel: ['"Press Start 2P"', 'Orbitron', 'monospace'],
+                        },
 			colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary
- add Press Start 2P font
- tweak pixel font stack in Tailwind config
- update hero tagline to highlight games and anime
- add Instagram handle @believestor.e in footer with icons
- enhance minigame layouts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_683e11499c60832181883a8a05f8483e