### PR TITLE
Fix Snake Retro game start logic

### DIFF
--- a/src/components/games/SnakeGame.tsx
+++ b/src/components/games/SnakeGame.tsx
@@ -17,24 +17,34 @@ const SnakeGame = ({ onPointsEarned }: SnakeGameProps) => {
   const [gameRunning, setGameRunning] = useState(false);
   const [score, setScore] = useState(0);
 
-  const generateFood = useCallback(() => {
-    return {
-      x: Math.floor(Math.random() * BOARD_SIZE),
-      y: Math.floor(Math.random() * BOARD_SIZE),
-    };
-  }, []);
+  const generateFood = useCallback((currentSnake: Array<{ x: number; y: number }> = snake) => {
+    let newFood;
+    do {
+      newFood = {
+        x: Math.floor(Math.random() * BOARD_SIZE),
+        y: Math.floor(Math.random() * BOARD_SIZE),
+      };
+    } while (currentSnake.some(segment => segment.x === newFood.x && segment.y === newFood.y));
+
+    return newFood;
+  }, [snake]);
 
   const resetGame = () => {
-    setSnake(INITIAL_SNAKE);
-    setFood(INITIAL_FOOD);
+    const initialSnake = INITIAL_SNAKE;
+    setSnake(initialSnake);
+    setFood(generateFood(initialSnake));
     setDirection({ x: 0, y: 0 });
     setScore(0);
     setGameRunning(false);
   };
 
   const startGame = () => {
-    setGameRunning(true);
+    const initialSnake = INITIAL_SNAKE;
+    setSnake(initialSnake);
+    setFood(generateFood(initialSnake));
+    setScore(0);
     setDirection({ x: 1, y: 0 });
+    setGameRunning(true);
   };
 
   const handleKeyPress = useCallback((e: KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- randomize food position each game
- reset snake and food on start and restart to avoid lingering state

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_683eeccb8b60832187715a999f8c78e3