### PR TITLE
Fix signup email redirect

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -33,6 +33,7 @@ const Auth = ({ user, onAuthChange }: AuthProps) => {
           email,
           password,
           options: {
+            emailRedirectTo: window.location.origin,
             data: {
               display_name: name,
             }


### PR DESCRIPTION
## Summary
- fix `supabase.auth.signUp` call to set `emailRedirectTo` to the current origin

## Testing
- `npm run build:dev` *(fails: vite not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68419f1716f88321b76185dccabb64a8