### PR TITLE
Handle signup error for existing users

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -39,8 +39,16 @@ const Auth = ({ user, onAuthChange }: AuthProps) => {
             }
           }
         });
-        if (error) throw error;
-        toast.success('Conta criada! Verifique seu email.');
+        if (error) {
+          if (error.message && error.message.toLowerCase().includes('already')) {
+            toast.error('Email j\u00e1 cadastrado. Tente fazer login.');
+            setIsLogin(true);
+          } else {
+            throw error;
+          }
+        } else {
+          toast.success('Conta criada! Verifique seu email.');
+        }
       }
       onAuthChange();
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- handle signup when the email is already registered

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6841c9b4a1988321aeba1794027e0ef0