### PR TITLE
Fix email redirect URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_EMAIL_REDIRECT_URL=https://yourdomain.com

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ npm i
 
 # Step 4: Start the development server with auto-reloading and an instant preview.
 npm run dev
+
+# Optional: set the URL used in email confirmations
+cp .env.example .env
+# Update `VITE_EMAIL_REDIRECT_URL` in `.env` with your deployed domain
 ```
 
 **Edit a file directly in GitHub**

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -29,11 +29,12 @@ const Auth = ({ user, onAuthChange }: AuthProps) => {
         if (error) throw error;
         toast.success('Login realizado com sucesso!');
       } else {
+        const EMAIL_REDIRECT_URL = import.meta.env.VITE_EMAIL_REDIRECT_URL || window.location.origin;
         const { error } = await supabase.auth.signUp({
           email,
           password,
           options: {
-            emailRedirectTo: window.location.origin,
+            emailRedirectTo: EMAIL_REDIRECT_URL,
             data: {
               display_name: name,
             }


### PR DESCRIPTION
## Summary
- use env var `VITE_EMAIL_REDIRECT_URL` for sign-up confirmation
- document how to set up `.env`
- add `.env.example` placeholder

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6841d7f2f9dc832185e1997c11a4b024