### PR TITLE
Set email redirect URL to Netlify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-VITE_EMAIL_REDIRECT_URL=https://yourdomain.com
+VITE_EMAIL_REDIRECT_URL=https://believestoresualojageek.netlify.app

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ npm run dev
 
 # Optional: set the URL used in email confirmations
 cp .env.example .env
-# Update `VITE_EMAIL_REDIRECT_URL` in `.env` with your deployed domain
+# `.env.example` is preconfigured for
+# https://believestoresualojageek.netlify.app.
+# Update `VITE_EMAIL_REDIRECT_URL` in `.env` if you deploy elsewhere
 ```
 
 **Edit a file directly in GitHub**


### PR DESCRIPTION
## Summary
- preconfigure `.env.example` to use the Netlify domain
- clarify README about using this Netlify URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841dc25d21083219a67ff97356deef5