### PR TITLE
Fix Stripe checkout configuration handling

### DIFF
--- a/supabase/functions/list-products/index.ts
+++ b/supabase/functions/list-products/index.ts
@@ -15,15 +15,10 @@ serve(async (req) => {
   try {
     console.log('Iniciando busca de produtos do Stripe...');
     
-    // Usar a chave secreta do Stripe configurada (somente modo de produção)
     const stripeKey = Deno.env.get("STRIPE_SECRET_KEY");
 
     if (!stripeKey) {
-      throw new Error("STRIPE_SECRET_KEY não configurada para produção");
-    }
-
-    if (stripeKey.startsWith("sk_test")) {
-      throw new Error("STRIPE_SECRET_KEY deve ser uma chave live (sk_live_*) para aceitar cartões reais");
+      throw new Error("STRIPE_SECRET_KEY não configurada");
     }
 
     const stripe = new Stripe(stripeKey, {


### PR DESCRIPTION
## Summary
- allow Stripe secret key to use either live or test keys and provide clearer error for missing configuration
- add graceful handling for missing Authorization header when creating a checkout session
- fall back to configured site URL when building success and cancel URLs to avoid invalid session URLs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6932d532bb408321a280d21f5068a8cd)