### PR TITLE
Adjust shipping handling before Stripe checkout

### DIFF
--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -112,7 +112,7 @@ const PaymentSuccess = () => {
               Você receberá um email de confirmação em breve com os detalhes da entrega.
             </p>
             <p className="text-gray-300">
-              O endereço informado no checkout do Stripe será usado para calcular e confirmar o frete.
+              O endereço informado antes do pagamento será usado diretamente para envio, sem exigir um novo checkout de frete no Stripe.
             </p>
             <p className="text-gray-300">
               O produto será entregue aos Correios em até 7 dias úteis após a confirmação do pagamento.

--- a/supabase/functions/create-payment/index.ts
+++ b/supabase/functions/create-payment/index.ts
@@ -83,25 +83,6 @@ serve(async (req) => {
     const session = await stripe.checkout.sessions.create({
       customer: customerId,
       customer_email: customerId ? undefined : user.email,
-      shipping_address_collection: {
-        allowed_countries: ["BR"],
-      },
-      shipping_options: [
-        {
-          shipping_rate_data: {
-            display_name: `Envio para ${shippingCity}/${shippingState}`,
-            type: "fixed_amount",
-            fixed_amount: {
-              amount: shippingAmountCents,
-              currency: "brl",
-            },
-            delivery_estimate: {
-              minimum: { unit: "business_day", value: 3 },
-              maximum: { unit: "business_day", value: 7 },
-            },
-          },
-        },
-      ],
       metadata: {
         shipping_city: shippingCity,
         shipping_state: shippingState,
@@ -114,6 +95,17 @@ serve(async (req) => {
             currency: "brl",
             product_data: { name: productName },
             unit_amount: productAmountCents,
+          },
+          quantity: 1,
+        },
+        {
+          price_data: {
+            currency: "brl",
+            product_data: {
+              name: `Frete para ${shippingCity}/${shippingState}`,
+              description: `Envio para ${shippingCep}`,
+            },
+            unit_amount: shippingAmountCents,
           },
           quantity: 1,
         },


### PR DESCRIPTION
## Summary
- remove Stripe shipping address collection and instead include the freight charge as a separate line item to avoid conflicts with prior checkout logic
- keep shipping address details in session metadata for reference alongside the product line item
- update the payment success page copy to reflect that shipping is handled before Stripe checkout

## Testing
- not run (npm CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6932d9f3ce24832185b12db2756516f5)