### PR TITLE
Add WhatsApp support contact CTA

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 
-import { Mail, Phone, Instagram } from 'lucide-react';
+import { Mail, Phone, Instagram, MessageCircle } from 'lucide-react';
 
 const Footer = () => {
   return (
@@ -32,11 +32,20 @@ const Footer = () => {
                 <Mail className="w-4 h-4 text-cyan-400" />
               </a>
               <a
-                href="tel:+5511999999999"
+                href="tel:+5585981849737"
                 className="w-8 h-8 bg-purple-400/20 rounded-full flex items-center justify-center hover:bg-purple-400/40 transition-colors"
                 aria-label="Telefone"
               >
                 <Phone className="w-4 h-4 text-purple-400" />
+              </a>
+              <a
+                href="https://wa.me/5585981849737"
+                className="w-8 h-8 bg-green-400/20 rounded-full flex items-center justify-center hover:bg-green-400/40 transition-colors"
+                aria-label="WhatsApp"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <MessageCircle className="w-4 h-4 text-green-400" />
               </a>
               <a
                 href="https://instagram.com/believestor.e"
@@ -66,7 +75,10 @@ const Footer = () => {
             <h4 className="text-white font-bold mb-4">Contato</h4>
             <ul className="space-y-2 text-gray-400">
               <li>📧 contato@believestore.com</li>
-              <li>📱 (11) 99999-9999</li>
+              <li>📱 (85) 98184-9737</li>
+              <li>
+                💬 <a href="https://wa.me/5585981849737" target="_blank" rel="noopener noreferrer" className="hover:text-green-400">WhatsApp Suporte</a>
+              </li>
               <li>📸 <a href="https://instagram.com/believestor.e" target="_blank" rel="noopener noreferrer" className="hover:text-pink-400">@believestor.e</a></li>
               <li>📍 São Paulo, SP</li>
               <li>🕒 Seg-Sex 9h-18h</li>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -23,6 +23,14 @@ const Hero = () => {
             >
               JOGAR MINI-GAMES
             </a>
+            <a
+              href="https://wa.me/5585981849737"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-gradient-to-r from-green-500 to-emerald-600 text-white px-8 py-4 rounded-lg font-bold text-lg hover:scale-105 transition-transform shadow-lg shadow-green-500/25 flex items-center gap-2"
+            >
+              FALAR NO WHATSAPP
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a WhatsApp CTA on the hero to reach the support number directly
- update footer contact details and icons to point to the new WhatsApp and phone number

## Testing
- npm run lint (fails: pre-existing lint errors about explicit any and other warnings)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693748e69ee083218d8263900d0239eb)